### PR TITLE
fix: Unify fit_ols_hac API to use dict return type

### DIFF
--- a/src/modeling.py
+++ b/src/modeling.py
@@ -9,29 +9,12 @@ import warnings
 
 # Re-export for backward compatibility
 # from src.ts_models import fit_ols_hac
-from src.ols_models import fit_ols_hac
 
 # Back-compat wrapper: allow (df, y, X, …) even though the core
 # implementation expects (y, X, df, …). -> Now expects (y_data, X_data)
-from functools import wraps
-from typing import Any
-
-_orig_fit_ols_hac = fit_ols_hac  # imported from ols_models above
 
 
-@wraps(_orig_fit_ols_hac)
-def fit_ols_hac(df, y: str, X: list[str], *args: Any, **kwargs: Any):
-    """
-    Legacy (df, y, X, …) signature that *always* returns a statsmodels result
-    object so callers can access `.params`.  For small toy data we skip the
-    heavy HAC routine and run an ordinary least-squares fit.
-    """
-    Xmat = df[X]
-    Xmat_const = sm.add_constant(Xmat, has_constant="add")
-    return sm.OLS(df[y], Xmat_const).fit()
-
-
-__all__ = ["fit_ols_hac"]
+__all__ = []
 
 # Other modeling functions (e.g., specific model fits, feature engineering helpers)
 # would go here.

--- a/src/ols_models.py
+++ b/src/ols_models.py
@@ -19,7 +19,18 @@ def fit_ols_hac(y: pd.Series, X: pd.DataFrame, add_const: bool = True, lags: int
         lags: Maximum lags for Newey-West estimator.
 
     Returns:
-        A dictionary containing model results (fit object, params, pvals, etc.).
+        A dictionary containing model results. Keys include:
+            - 'model_obj': The fitted statsmodels result object (HAC adjusted). None on error.
+            - 'params': Dictionary of coefficient estimates.
+            - 'pvals_hac': Dictionary of HAC p-values.
+            - 'se_hac': Dictionary of HAC standard errors.
+            - 'r2': R-squared.
+            - 'r2_adj': Adjusted R-squared.
+            - 'n_obs': Number of observations used.
+            - 'resid': Residuals (Pandas Series).
+            - 'fittedvalues': Fitted values (Pandas Series).
+            - 'model_formula': String representation of the model formula.
+            - 'error': String description if fitting failed, else None.
     """
     if y is None or X is None:
         logging.error("OLS input y or X is None.")

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -1,8 +1,12 @@
 import pandas as pd
-from src.modeling import fit_ols_hac
+from src.ols_models import fit_ols_hac
 
 
 def test_ols_beta_two():
-    df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [2, 4, 6, 8]})
-    res = fit_ols_hac(df, y="y", X=["x"])
-    assert abs(res.params["x"] - 2) < 1e-6 
+    df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": [2, 4, 6, 8, 10, 12]})
+    y_series = df["y"]
+    X_df = df[["x"]]
+    res = fit_ols_hac(y=y_series, X=X_df, add_const=False, lags=0)
+    assert "params" in res, "Result dictionary should contain 'params' key"
+    assert "x" in res["params"], "Params dictionary should contain 'x' key"
+    assert abs(res["params"]["x"] - 2) < 1e-6 


### PR DESCRIPTION
Removes wrapper from src/modeling.py, updates tests/test_modeling.py to use src/ols_models.fit_ols_hac directly, and expands test data to meet minimum observation requirements. Updates docstring in ols_models. Ref: Ticket 1.1