### PR TITLE
feat(eda): implement leak-free winsorization per window

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ ethereum_project/
 *   `utils.py`: Contains shared utility functions, constants (like `DATA_DIR`), and logging configuration used across the project.
 *   `data_fetching.py`: Handles fetching raw data from external sources (e.g., CoinMetrics API, Yahoo Finance). Includes caching mechanisms to avoid redundant downloads.
 *   `data_processing.py`: Responsible for cleaning, transforming, merging, and resampling the raw data into the `daily_clean.parquet` and `monthly_clean.parquet` datasets used for analysis.
-*   `eda.py`: Provides functions for exploratory data analysis and preprocessing steps necessary before modeling, such as data winsorization and stationarity tests (e.g., ADF).
+*   `eda.py`: Provides functions for exploratory data analysis and preprocessing steps necessary before modeling. This includes *leak-free* data winsorization (calculating quantiles based only on the relevant training window to prevent lookahead bias) and stationarity tests (e.g., ADF).
 *   `modeling.py`: Implements the core econometric models, including Ordinary Least Squares (OLS) benchmarks, Vector Error Correction Models (VECM), Autoregressive Distributed Lag (ARDL) models, residual diagnostics, structural break tests, and out-of-sample validation.
+*   `validation.py`: Handles out-of-sample model validation, specifically implementing rolling window validation. Preprocessing steps like winsorization are applied *within* each training window iteration to prevent lookahead bias / data leakage.
 *   `reporting.py`: Contains functions to generate summaries of the analysis results, format them into a structured dictionary, create interpretation text, and handle JSON serialization (including custom encoders for NumPy types).
 
 ## Setup

--- a/main.py
+++ b/main.py
@@ -153,7 +153,14 @@ def main():
     if all(col in monthly_winsorized.columns for col in oos_req_cols):
          # Pass the winsorized df, OOS function will handle NaN dropping internally for its specific needs
          # Reverted: Uses locally defined OOS_WINDOW
-         oos_results = run_oos_validation(monthly_winsorized, OOS_ENDOG_COL, OOS_EXOG_COLS, window_size=OOS_WINDOW)
+         oos_results = run_oos_validation(
+            df_monthly=monthly_winsorized,
+            endog_col=OOS_ENDOG_COL,
+            exog_cols=OOS_EXOG_COLS,
+            winsorize_cols=WINSORIZE_COLS,
+            winsorize_quantile=WINSORIZE_QUANTILE,
+            window_size=OOS_WINDOW
+        )
          analysis_results['oos'] = oos_results
          # Add OOS predictions back to the main modeling dataframe if successful
          if 'predictions_df' in oos_results:

--- a/tests/test_winsor_leak.py
+++ b/tests/test_winsor_leak.py
@@ -1,0 +1,51 @@
+# tests/test_winsor_leak.py
+
+import pandas as pd
+import numpy as np
+import pytest  # Make sure pytest is imported if needed for fixtures, etc.
+
+# Assuming src is importable due to conftest.py or PYTHONPATH setup
+from src.eda import winsorize_data
+
+def test_winsorize_leakage_prevention():
+    """
+    Tests that winsorizing with a window_mask only uses data within
+    that window to calculate the quantile cap, preventing future leakage.
+    """
+    # 1. Create toy data with an obvious outlier in the 'future'
+    dates = pd.to_datetime(['2023-01-01', '2023-01-02', '2023-01-03',
+                            '2023-01-04', '2023-01-05', '2023-01-06'])
+    # Normal values in the past, huge outlier in the future
+    data = {'value': [10, 12, 11, 13, 1000, 15]}
+    df = pd.DataFrame(data, index=dates)
+    original_future_value = df.loc['2023-01-05', 'value'] # Store the outlier value
+
+    # 2. Define the 'past' window mask (excluding the outlier date)
+    past_window_mask = df.index < '2023-01-05'
+    cols_to_cap = ['value']
+    quantile_to_cap = 0.90 # Set quantile low enough to cap something in the past window
+
+    # 3. Call winsorize_data using only the past window for quantile calculation
+    df_winsorized = winsorize_data(
+        df=df.copy(), # Pass a copy to avoid modifying original df if reused
+        cols_to_cap=cols_to_cap,
+        quantile=quantile_to_cap,
+        window_mask=past_window_mask # CRITICAL: use only past data for cap calc
+    )
+
+    # 4. Assertions
+    # a) The future outlier should NOT have been changed
+    assert df_winsorized.loc['2023-01-05', 'value'] == original_future_value, \
+        "Future outlier value was incorrectly modified by winsorizing based on past window."
+
+    # b) Check that capping *did* happen based on the past window's quantile
+    #    The cap value should be the 90th percentile of [10, 12, 11, 13] = 12.8
+    expected_cap_value = np.percentile([10, 12, 11, 13], 90)
+    # Find the max value in the past window in the *winsorized* data
+    max_past_winsorized_value = df_winsorized.loc[past_window_mask, 'value'].max()
+    assert max_past_winsorized_value <= expected_cap_value, \
+        f"Value in past window ({max_past_winsorized_value}) exceeds expected cap value ({expected_cap_value}) based on past data."
+
+    # c) Verify a specific past value *was* capped (e.g., the 13)
+    assert df_winsorized.loc['2023-01-04', 'value'] == expected_cap_value, \
+        "Expected past value (13) was not capped to the calculated threshold." 


### PR DESCRIPTION
- Adds window_mask parameter to eda.winsorize_data to calculate quantiles based only on the specified window.
- Modifies validation.run_oos_validation to use the training window index when calling winsorize_data.
- Adds unit test test_winsor_leak.py to verify future data does not affect past winsorization.
- Updates README descriptions for eda.py and validation.py.

Relates to #<issue_number> # Optional: Link to your issue tracker ID