### PR TITLE
feat: snapshot raw API payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       run: pip install -r requirements-lock.txt
 
     - name: Run tests
+      env:
+        RAPIDAPI_KEY: "dummy_key_for_testing"
       run: pytest -q
 
     # Add other steps like linting, testing, etc.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ env/
 */ENV/
 */env/
 
+snapshots/
+
 # Distribution / packaging
 .Python
 build/

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     BASE_DIR: Path = Path(__file__).resolve().parent.parent
     # Data directory derived from BASE_DIR
     DATA_DIR: Path = BASE_DIR / "data"
+    # Directory for raw API response snapshots
+    RAW_SNAPSHOT_DIR: Path = BASE_DIR / "snapshots"
 
     class Config:
         env_file = ".env"

--- a/src/data_fetching.py
+++ b/src/data_fetching.py
@@ -60,7 +60,8 @@ def fetch_eth_price_rapidapi() -> pd.DataFrame:
         response_json = None
         try:
             # Use robust_get imported from utils
-            response_json = robust_get(url, headers=hdrs, params=params)
+            prefix = f"yf_eth_{start.strftime('%Y%m%d')}_{end.strftime('%Y%m%d')}"
+            response_json = robust_get(url, headers=hdrs, params=params, snapshot_prefix=prefix)
 
             # Defensive parsing checks (ensure structure is as expected)
             chart_data = response_json.get("chart", {})
@@ -184,7 +185,8 @@ def cm_fetch(metric: str, asset="eth", start="2015-08-01", freq="1d") -> pd.Seri
         logging.debug(f"Fetching CM page {page_count}: {url.split('?')[0]}...")
         try:
             # Use robust_get imported from utils
-            j = robust_get(url, headers=hdr)
+            prefix = f"cm_{asset}_{metric}_p{page_count}"
+            j = robust_get(url, headers=hdr, snapshot_prefix=prefix)
             page_data = j.get("data", [])
             data.extend(page_data)
             url = j.get("next_page_url")
@@ -265,7 +267,8 @@ def fetch_nasdaq() -> pd.Series:
         response_json = None
         try:
             # Use robust_get imported from utils
-            response_json = robust_get(url, headers=hdrs, params=params)
+            prefix = f"yf_ndx_{start.strftime('%Y%m%d')}_{end.strftime('%Y%m%d')}"
+            response_json = robust_get(url, headers=hdrs, params=params, snapshot_prefix=prefix)
 
             # Defensive parsing checks
             chart_data = response_json.get("chart", {})

--- a/tests/test_snapshot_creation.py
+++ b/tests/test_snapshot_creation.py
@@ -1,0 +1,61 @@
+# tests/test_snapshot_creation.py
+
+import pytest
+import requests
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch # For mocking requests.Response and patching
+
+# Assuming src is importable due to conftest.py or PYTHONPATH setup
+from src.config import settings
+# from src.data_fetching import cm_fetch # Use cm_fetch as an example fetcher
+from src.utils import robust_get # <-- Import directly
+
+# Define mock API response data
+MOCK_API_DATA = {
+    "data": [
+        {"time": "2023-01-01T00:00:00Z", "Value": "100"}, # Changed key for variety
+        {"time": "2023-01-02T00:00:00Z", "Value": "110"},
+    ],
+    "next_page_url": None,
+}
+
+# Target the function *where it's looked up* (in src.utils module)
+@patch('src.utils._save_api_snapshot')
+def test_robust_get_snapshot_call(mock_save_snapshot, monkeypatch, tmp_path):
+    """
+    Tests that robust_get calls _save_api_snapshot with correct arguments
+    when a snapshot_prefix is provided, by calling robust_get directly.
+    """
+    # 1. Mock snapshot directory (DATA_DIR mocking not needed for this test)
+    snapshot_dir = tmp_path / "snapshots"
+    monkeypatch.setattr(settings, 'RAW_SNAPSHOT_DIR', snapshot_dir)
+
+    # 2. Mock requests.get to return a controlled response
+    mock_response = MagicMock(spec=requests.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = MOCK_API_DATA
+    mock_response.content = json.dumps(MOCK_API_DATA).encode('utf-8')
+    def mock_get(*args, **kwargs):
+        mock_response.raise_for_status()
+        return mock_response
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    # 3. Call robust_get directly
+    test_url = "http://fake.api/data"
+    test_prefix = "test_snapshot_prefix"
+    result_data = robust_get(url=test_url, snapshot_prefix=test_prefix)
+
+    # 4. Assertions on the *mock* object and result
+    # a) Check the returned data is correct
+    assert result_data == MOCK_API_DATA, "robust_get did not return the expected data."
+
+    # b) Check if _save_api_snapshot was called exactly once
+    mock_save_snapshot.assert_called_once()
+
+    # c) Check the arguments it was called with
+    call_args, call_kwargs = mock_save_snapshot.call_args
+    # call_args is a tuple: (directory, filename_prefix, data)
+    assert call_args[0] == snapshot_dir, "Snapshot helper not called with correct directory."
+    assert call_args[1] == test_prefix, "Snapshot helper not called with correct prefix."
+    assert call_args[2] == MOCK_API_DATA, "Snapshot helper not called with correct data." 


### PR DESCRIPTION
- Adds RAW_SNAPSHOT_DIR setting to config.py.
- Adds helper _save_api_snapshot to utils.py.
- Modifies utils.robust_get to accept snapshot_prefix and call helper.
- Updates fetchers in data_fetching.py to pass snapshot_prefix.
- Adds snapshots/ directory and .gitkeep, updates .gitignore.
- Adds unit test test_snapshot_creation.py verifying the call to the snapshot helper within robust_get.

Relates to #<issue_number> # Optional: Link issue ID