### PR TITLE
chore: Pin flake8-bugbear version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear>=23.9.16
+          - flake8-bugbear==23.9.16
         args:
           - --max-line-length=88
           - --ignore=E203,E501,W503


### PR DESCRIPTION
Pins flake8-bugbear to an exact version (==23.9.16) for consistent linting results, addressing an audit recommendation.