### PR TITLE
feat: Add pytest-xdist for parallel testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 pytest==7.2.0
 pytest-cov==4.0.0
-coverage==6.4.1
+pytest-xdist==3.6.1
+coverage==7.8.0
 
 ruff==0.0.241
 mypy==1.15.0

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -22,7 +22,7 @@ colorama==0.4.6
     # via radon
 contourpy==1.3.2
     # via matplotlib
-coverage[toml]==6.4.1
+coverage[toml]==7.8.0
     # via
     #   -r requirements-dev.txt
     #   pytest-cov
@@ -34,6 +34,8 @@ distlib==0.3.9
     # via virtualenv
 dparse==0.6.4
     # via safety
+execnet==2.1.1
+    # via pytest-xdist
 filelock==3.16.1
     # via virtualenv
 fonttools==4.57.0
@@ -111,7 +113,10 @@ pytest==7.2.0
     # via
     #   -r requirements-dev.txt
     #   pytest-cov
+    #   pytest-xdist
 pytest-cov==4.0.0
+    # via -r requirements-dev.txt
+pytest-xdist==3.6.1
     # via -r requirements-dev.txt
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
- Adds pytest-xdist to development dependencies.
- Updates coverage package to resolve pip-compile issue.
- Regenerates requirements-lock.txt.

This enables the -n auto flag for pytest in CI to speed up test execution, addressing an audit recommendation.