### PR TITLE
chore: Remove unused pip.conf and update docs

### DIFF
--- a/PROJECT_CONFIG_DETAILS.md
+++ b/PROJECT_CONFIG_DETAILS.md
@@ -294,13 +294,6 @@ ignore_errors = True
 ignore_missing_imports = True
 ```
 
-## `pip.conf`
-
-```ini
-[global]
-extra-index-url = https://pypi.fury.io/arrow-nightlies/
-```
-
 ## GitHub Actions Workflows
 
 This project utilizes several GitHub Actions workflows for CI, testing, and automation.

--- a/pip.conf
+++ b/pip.conf
@@ -1,2 +1,0 @@
-[global]
-extra-index-url = https://pypi.fury.io/arrow-nightlies/


### PR DESCRIPTION
- Deletes pip.conf as the extra-index-url for arrow-nightlies is no longer needed.
- Removes the corresponding pip.conf section from PROJECT_CONFIG_DETAILS.md.

This addresses an audit finding regarding potentially unnecessary nightly/unstable dependency sources.