### PR TITLE
fix: Ensure all CI workflows use Python 3.12

### DIFF
--- a/.github/workflows/nightly_audit.yml
+++ b/.github/workflows/nightly_audit.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
-        with: {python-version: '3.11'}
+        with: {python-version: '3.12'}
       - name: Install dev deps
         run: |
           python -m pip install -r requirements-dev.txt

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Updates python-version to 3.12 in nightly_audit.yml.
- Updates python-version matrix to 3.12 in python-ci.yml.

These changes ensure all workflows align with the project's standardization on Python 3.12.