### PR TITLE
feat: Add pre-commit hook to limit staged files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,11 @@ repos:
 
 # TODO: Consider adding a Markdown link checker if a suitable pre-commit hook is found.
 # Many robust link checkers are full CI actions (e.g., lychee).
+
+  - repo: local
+    hooks:
+      - id: too-many-files
+        name: Too many staged files
+        entry: bash -c '[[ $(git diff --cached --name-only | wc -l) -le 25 ]]'
+        language: system
+        stages: [commit]


### PR DESCRIPTION
This PR introduces a new local pre-commit hook that will cause a commit to fail if more than 25 files are staged. This is to encourage smaller, more atomic commits. Experiment 12-1.