### PR TITLE
Feat: Add Push Frequency Guard CI (Exp 12-2)

### DIFF
--- a/.github/workflows/push-frequency.yml
+++ b/.github/workflows/push-frequency.yml
@@ -1,0 +1,18 @@
+name: Push Frequency Guard
+on:
+  pull_request:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6 h
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if branch too far ahead
+        run: |
+          git fetch origin main
+          COMMITS=$(git rev-list --count origin/main..HEAD)
+          if [ "$COMMITS" -gt 5 ]; then
+            echo "::error title=Push too large::Branch is $COMMITS commits ahead of main"
+            exit 1
+          fi 

--- a/docs/dev_agent_experiments/README.md
+++ b/docs/dev_agent_experiments/README.md
@@ -30,13 +30,13 @@
    Exceeding this means: log attempts, mark "Partially Complete", move on.
 
 7. **Regular Integration of Changes (Full Cycle Workflow):**
-   • After completing an experiment or a set of related documentation updates (e.g., to this README, the plan, or the execution log), the agent should strive to integrate these changes into the main repository through a full PR cycle.
-   • This includes: creating a branch, committing changes (satisfying pre-commit hooks), pushing the branch, creating a PR, monitoring CI checks, merging the PR upon success, and performing local git cleanup (switching to main, pulling, deleting the feature branch).
-   • This practice avoids large accumulations of unmerged changes, which can complicate pre-commit hook resolution and CI validation, as experienced during the resolution of PR #122.
-   • For minor, purely documentation changes related to ongoing experiments, these can sometimes be batched, but the agent should bias towards more frequent, smaller integrations if many files are touched or if pre-commit issues are anticipated.
+   • After completing an experiment or a significant set of related documentation updates (e.g., to this README, the plan, or the execution log), the agent MUST update the `github_cli_execution_log.md` with a comprehensive entry for the actions taken *before* proceeding to the commit and push steps.
+   • The ideal workflow is: Perform Actions -> Update Log -> Commit -> Push -> Create PR -> Monitor CI -> Merge -> Local Cleanup.
+   • This practice avoids large accumulations of unmerged changes and ensures logs are part of the PR, preventing an out-of-sync state post-merge. This was a key learning from PR #122 and PR #123 resolutions.
+   • For minor, purely documentation changes related to ongoing experiments, these can sometimes be batched, but the logging should still precede the commit of those batched changes.
 
-8. **Final Action - Ensure Full Sync:**
-   • Before concluding an experiment run or a significant interaction block with the user, the agent's *final action* must be to ensure that all modified experimental artifacts (code, logs, plans, READMEs) are committed, pushed, merged via PR (after passing CI), and that the local repository is tidied up (on `main`, updated, and feature branch deleted). This leaves the repository in a clean and synchronized state for future work or the next agent session.
+8. **Final Action - Ensure Full Sync (Log First!):**
+   • Before concluding an experiment run or a significant interaction block with the user, the agent's *final actions* must be: 1) Update all relevant documentation (especially `github_cli_execution_log.md`). 2) Ensure these documentation changes AND any experimental code/config changes are committed, pushed, merged via PR (after passing CI). 3) Perform local repository cleanup (on `main`, updated, and feature branch deleted). This leaves the repository in a clean and synchronized state for future work or the next agent session.
 
 Failure to follow these rules counts as an experiment failure.
 ────────────────────────────────────────────────────────

--- a/docs/dev_agent_experiments/github_cli_plan.md
+++ b/docs/dev_agent_experiments/github_cli_plan.md
@@ -104,6 +104,15 @@ This roadmap tracks experiments that probe an LLM agent's ability to manage a Gi
 
 ---
 
+## Experiment Set 12 — Custom Pre-commit Hooks for Repo Policy
+
+| ID    | Focus                                  | Priority | Status |
+|-------|----------------------------------------|----------|--------|
+| 12-1  | Limit number of staged files (<25)     | ◼︎ Med   | **Done (Run 6)** |
+| 12-2  | CI check for push frequency (>5 commits)| ◼︎ Med   | **In Progress (Run 6)** |
+
+---
+
 ## Back-burner Sets (no change)
 
 *Set 5 (old)* — Diff-First workflow (JSON-only decision loop)  
@@ -120,7 +129,7 @@ This roadmap tracks experiments that probe an LLM agent's ability to manage a Gi
 * Mini-summaries, chunked logs  
 * Raw stdout/stderr goes into `github_cli_execution_log.md`  
 * **No 4 000-token pause** — Agent must run uninterrupted.
-* **Regular Integration:** Changes related to experiments or their documentation (plan, log, README updates) should be integrated frequently via a full PR cycle (branch, commit with passing hooks, push, PR, CI checks, merge, local cleanup). This avoids large, problematic accumulations of changes.
+* **Regular Integration (Log First!):** Changes related to experiments or their documentation (plan, log, README updates) MUST be logged to `github_cli_execution_log.md` *before* being committed. The full cycle is: Experiment Actions -> Log Updates -> Commit (passing hooks) -> Push -> PR -> CI -> Merge -> Local Cleanup. This avoids out-of-sync logs and large, problematic change accumulations.
 
 ---
 


### PR DESCRIPTION
Adds a GitHub Actions workflow to check if a PR branch is more than 5 commits ahead of origin/main. Includes updates to dev agent experiment documentation regarding hygiene rules. Experiment 12-2.