### PR TITLE
Docs: Refine hygiene rules for agent integration workflow

### DIFF
--- a/docs/dev_agent_experiments/README.md
+++ b/docs/dev_agent_experiments/README.md
@@ -29,14 +29,14 @@
    Each experiment gets **≤ 20 minutes or ≤ 3 failed attempts**.  
    Exceeding this means: log attempts, mark "Partially Complete", move on.
 
-7. **Regular Integration of Changes (Full Cycle Workflow):**
-   • After completing an experiment or a significant set of related documentation updates (e.g., to this README, the plan, or the execution log), the agent MUST update the `github_cli_execution_log.md` with a comprehensive entry for the actions taken *before* proceeding to the commit and push steps.
-   • The ideal workflow is: Perform Actions -> Update Log -> Commit -> Push -> Create PR -> Monitor CI -> Merge -> Local Cleanup.
-   • This practice avoids large accumulations of unmerged changes and ensures logs are part of the PR, preventing an out-of-sync state post-merge. This was a key learning from PR #122 and PR #123 resolutions.
-   • For minor, purely documentation changes related to ongoing experiments, these can sometimes be batched, but the logging should still precede the commit of those batched changes.
+7. **Regular Integration – after every experiment or non-trivial doc edit:**
+   • Agent MUST update `github_cli_execution_log.md` with a comprehensive entry for the actions taken *before* committing.
+   • Workflow: `Perform Actions -> Update Log -> git add → commit → push → open PR → wait for CI → merge → pull main.`
+   • *Rationale*: This practice avoids large accumulations of unmerged changes and ensures logs are part of the PR, preventing an out-of-sync state post-merge. This was a key learning from PR #122 and PR #123 resolutions. For minor, purely documentation changes, these can sometimes be batched, but logging should still precede the commit of batched changes.
 
-8. **Final Action - Ensure Full Sync (Log First!):**
-   • Before concluding an experiment run or a significant interaction block with the user, the agent's *final actions* must be: 1) Update all relevant documentation (especially `github_cli_execution_log.md`). 2) Ensure these documentation changes AND any experimental code/config changes are committed, pushed, merged via PR (after passing CI). 3) Perform local repository cleanup (on `main`, updated, and feature branch deleted). This leaves the repository in a clean and synchronized state for future work or the next agent session.
+8. **Final Action – ensure local main is up-to-date and workspace clean:**
+   • *Log First!* Before concluding an experiment run or significant interaction, the agent's *final actions* must be: 1) Update all relevant documentation (especially `github_cli_execution_log.md`). 2) Ensure these documentation changes AND any experimental code/config changes are committed, pushed, merged via PR (after passing CI). 3) Perform local repository cleanup (on `main`, updated, and feature branch deleted).
+   • *Rationale*: This leaves the repository in a clean and synchronized state for future work or the next agent session.
 
 Failure to follow these rules counts as an experiment failure.
 ────────────────────────────────────────────────────────

--- a/docs/dev_agent_experiments/github_cli_execution_log.md
+++ b/docs/dev_agent_experiments/github_cli_execution_log.md
@@ -1232,3 +1232,21 @@ The new "Push Frequency Guard" CI workflow was successfully implemented and test
 
 **Mini-Summary (Experiment 12-2):**
 Successfully added `.github/workflows/push-frequency.yml` to check if PR branches are >5 commits ahead of main. Logged actions before commit. PR #125 created, new `guard` CI check (run ID `14959797914`) passed. PR merged and branches cleaned up. Experiment completed.
+
+---
+
+### Docs: Refine Hygiene Rules for Integration Workflow (Experiment 12-3)
+
+**Agent's Pre-Action Reasoning (Chain of Thought - CoT):**
+Based on user feedback and learnings from previous PR merges, the hygiene rules regarding regular integration of changes and final synchronization steps need to be more precise and emphasize logging *before* commits.
+
+**Actions Taken:**
+1.  Created branch `experiment/12-3-readme-rule-refinement`.
+2.  Edited `docs/dev_agent_experiments/README.md` to refine Hygiene Rules #7 and #8 with more concise titles and action summaries, while retaining important rationale regarding logging first and preventing change accumulation.
+
+**Next Steps (To be logged after execution):**
+- Commit the `README.md` changes.
+- Push the branch.
+- Create a Pull Request.
+- Monitor CI checks.
+- Merge the PR and perform local cleanup.

--- a/docs/dev_agent_experiments/github_cli_plan.md
+++ b/docs/dev_agent_experiments/github_cli_plan.md
@@ -110,6 +110,7 @@ This roadmap tracks experiments that probe an LLM agent's ability to manage a Gi
 |-------|----------------------------------------|----------|--------|
 | 12-1  | Limit number of staged files (<25)     | ◼︎ Med   | **Done (Run 6)** |
 | 12-2  | CI check for push frequency (>5 commits)| ◼︎ Med   | **Done (Run 6)** |
+| 12-3  | Refine README hygiene rules (log first)  | ◼︎ Med   | **In Progress (Run 6)** |
 
 ---
 


### PR DESCRIPTION
Refines hygiene rules #7 and #8 in the dev_agent_experiments README to emphasize logging before commits and provide clearer action summaries for the regular integration cycle. Experiment 12-3.