### PR TITLE
CI: Add test for too-many-files hook

### DIFF
--- a/.github/workflows/hook-guard-test.yml
+++ b/.github/workflows/hook-guard-test.yml
@@ -1,0 +1,36 @@
+name: Hook Guard Test
+on: pull_request
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install pre-commit
+      - name: Install git hooks
+        run: pre-commit install --install-hooks
+      - name: Create 26 dummy files & test hook
+        run: |
+          mkdir tmp_guard && cd tmp_guard
+          seq 26 | xargs -I{} touch f-{}.txt
+          git add .
+          echo "Attempting commit which should be blocked by the too-many-files hook..."
+          # The following git commit is expected to fail if the hook works.
+          git commit -m "CI: Test commit for too-many-files hook"
+          COMMIT_EXIT_CODE=$?
+          if [ $COMMIT_EXIT_CODE -eq 0 ]; then
+            echo "::error title=Hook Problem::Commit succeeded but should have been blocked by the too-many-files hook."
+            exit 1 # Fail CI because hook didn't block
+          elif [ $COMMIT_EXIT_CODE -eq 1 ]; then
+            # This is the expected failure from our hook.
+            # The hook should have printed its own error message to stdout/stderr.
+            echo "Commit correctly blocked by hook (git commit exited with 1). This CI job will now also exit with 1, failing as designed, to indicate the hook is working."
+            exit 1 # Explicitly fail the CI job to signal "test condition met"
+          else
+            echo "::error title=Unexpected Commit Failure::Commit failed with unexpected exit code $COMMIT_EXIT_CODE (expected 1 if hook blocked)."
+            exit $COMMIT_EXIT_CODE # Fail CI with the unexpected code
+          fi 

--- a/.github/workflows/hook-guard-test.yml
+++ b/.github/workflows/hook-guard-test.yml
@@ -15,6 +15,8 @@ jobs:
         run: pre-commit install --install-hooks
       - name: Create 26 dummy files & test hook
         run: |
+          git config --global user.email "test-runner@github.com"
+          git config --global user.name "Test Runner"
           mkdir tmp_guard && cd tmp_guard
           seq 26 | xargs -I{} touch f-{}.txt
           git add .

--- a/docs/dev_agent_experiments/github_cli_execution_log.md
+++ b/docs/dev_agent_experiments/github_cli_execution_log.md
@@ -1355,3 +1355,39 @@ The plan is:
 Initiating task to improve the 'too-many-files' pre-commit hook error message. Branch: `chore/hook-friendly-message`.
 
 ---
+
+### MAINT B: Add CI Test for 'too-many-files' Hook
+
+**Agent's Pre-Action Reasoning (Chain of Thought - CoT):**
+The user wants to add a CI workflow to test the `too-many-files` pre-commit hook. This workflow should intentionally try to commit more than 25 files. If the hook works correctly, it will block the commit, causing the `git commit` command in the CI script to fail. The CI job itself is designed to fail to indicate that the hook is functioning as expected.
+
+The plan is:
+1. Create branch: `ci/too-many-files-test`.
+2. Add the new workflow file `.github/workflows/hook-guard-test.yml`.
+3. This workflow will include steps to install pre-commit and the git hooks.
+4. The test step will create 26 dummy files, stage them, and attempt a commit.
+5. If `git commit` exits with 0 (commit succeeded, hook failed), the CI job will error.
+6. If `git commit` exits with 1 (commit blocked by hook, hook worked), the CI job will also be marked as failed (as per design, a failing test indicates the hook is protective).
+7. Commit the new workflow file and this log update.
+8. Push, PR, merge, and tidy. The merge might require admin privileges if the CI job failing blocks the PR.
+
+**Command(s) Executed:**
+```sh
+# Subsequent commands will be logged as they are executed.
+```
+
+**Observed Result(s) (Raw Output):**
+```
+# To be populated as commands are run.
+```
+
+**Agent's Post-Action Analysis (CoT & Interpretation):**
+# To be populated as the workflow progresses.
+
+**Learnings/Reflections:**
+# To be populated.
+
+**Mini-Summary:**
+Initiating task to add a CI test for the 'too-many-files' pre-commit hook. Branch: `ci/too-many-files-test`.
+
+---


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow () designed to test the  pre-commit hook. The workflow intentionally tries to commit 26 files. If the hook functions correctly, it will block this commit, and the CI job will fail (as an indication that the protection mechanism is working). Maintenance Prompt B.