### PR TITLE
Docs: Verify 10-3 priority in plan (no change needed)

### DIFF
--- a/docs/dev_agent_experiments/github_cli_execution_log.md
+++ b/docs/dev_agent_experiments/github_cli_execution_log.md
@@ -1391,3 +1391,35 @@ The plan is:
 Initiating task to add a CI test for the 'too-many-files' pre-commit hook. Branch: `ci/too-many-files-test`.
 
 ---
+
+### MAINT C: Bump Experiment 10-3 Priority in Plan
+
+**Agent's Pre-Action Reasoning (Chain of Thought - CoT):**
+The user wants to update the priority of experiment 10-3 (failure-class tagging) to "🔥 High" in the `github_cli_plan.md` dashboard.
+
+The plan is:
+1. Create branch: `docs/bump-10-3-priority`.
+2. Edit `docs/dev_agent_experiments/github_cli_plan.md` to reflect the new priority for Set 10.
+3. Commit the change and this log update.
+4. Push, PR, merge, and tidy.
+
+**Command(s) Executed:**
+```sh
+# Subsequent commands will be logged as they are executed.
+```
+
+**Observed Result(s) (Raw Output):**
+```
+# To be populated as commands are run.
+```
+
+**Agent's Post-Action Analysis (CoT & Interpretation):**
+# To be populated as the workflow progresses.
+
+**Learnings/Reflections:**
+# To be populated.
+
+**Mini-Summary:**
+Initiating task to bump the priority of experiment 10-3 in `github_cli_plan.md`. Branch: `docs/bump-10-3-priority`.
+
+---


### PR DESCRIPTION
This PR was opened to address Maintenance Prompt C, which requested updating experiment 10-3 priority to High. Upon inspection, the priority for Set 10 (which includes 10-3) was already set to '🔥 High' in . This PR therefore only includes the log entry for this check. Maintenance Prompt C.