### PR TITLE
Fix workflow YAML linter warning

### DIFF
--- a/.github/workflows/agent_headless.yml
+++ b/.github/workflows/agent_headless.yml
@@ -1,6 +1,6 @@
 name: Agent headless smoke-test
 
-on:
+'on':
   pull_request:
 
 jobs:


### PR DESCRIPTION
Quote 'on' key in agent_headless.yml to avoid YAML 1.1 boolean parsing issue.